### PR TITLE
Fix startup from sdcard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /downloads/
 /builds/
 .vscode/
+.DS_Store

--- a/base/common/uninstall.sh
+++ b/base/common/uninstall.sh
@@ -1,0 +1,13 @@
+#!/system/bin/sh
+# Do NOT assume where your module will be located.
+# ALWAYS use $MODDIR if you need to know where this script
+# and module is placed.
+# This will make sure your module will still work
+# if Magisk change its mount point in the future
+MODDIR=${0%/*}
+
+# This script will be executed in uninstall mode
+SDCARD_STORAGE="/storage/emulated/0/mfe-frida-server"
+if [ -d ${SDCARD_STORAGE} ]; then
+    rm -rf ${SDCARD_STORAGE}
+fi 

--- a/base/system/bin/mfe
+++ b/base/system/bin/mfe
@@ -113,13 +113,13 @@ cat > ${MODPATH}/service.sh << EOF
 MODDIR=${0%/*}
 
 # This script will be executed in late_start service mode
-while [ "\$(getprop sys.boot_completed)" != "1" ]; do
+while [ ! -d "/storage/emulated/0/mfe-frida-server" ]; do
     sleep 1
 done
 
 EOF
 
-    echo "mfe ${version}" >> ${MODPATH}/service.sh
+    echo "mfe ${version} >\${MODDIR}/mfe.log" >> ${MODPATH}/service.sh
 }
 
 

--- a/build.py
+++ b/build.py
@@ -69,7 +69,7 @@ MODDIR=${{0%/*}}
 #     sleep 1
 # done
 
-while [ ! -d "/storage/emulated/0" ]; do
+while [ ! -d "/storage/emulated/0/mfe-frida-server" ]; do
   sleep 1
 done
 


### PR DESCRIPTION
Hi 
On my device, frida wouldn't start correctly on boot and mfe.log would contain a "frida-server.* not exist" error.
This commit fixes it for me.
Also attempted to remove all the frida binaries from the sdcard when removing the module in magisk manager but it appears that the sdcard is not mounted yet when magisk calls the uninstall.sh script. Your mileage may vary.
Thanks